### PR TITLE
Fix haiku_example.py

### DIFF
--- a/examples/haiku_example.py
+++ b/examples/haiku_example.py
@@ -41,8 +41,8 @@ def main(argv):
   network = hk.without_apply_rng(hk.transform(forward_pass, apply_rng=True))
 
   # Some arbitrary loss.
-  def mean_square_loss(x):
-    output = network.apply(x)
+  def mean_square_loss(params, x):
+    output = network.apply(params, x)
     loss = jnp.sum(output**2)
     return loss, loss
 


### PR DESCRIPTION
I seemed to be getting:

```python
TypeError: mean_square_loss() takes 1 positional argument but 2 were given
```

So I think this fixes it.