### PR TITLE
Add piecewise_interpolate_schedule, linear_onecycle, and cos_onecycle.

### DIFF
--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -30,8 +30,11 @@ from optax._src.control_variates import control_variates_jacobians
 from optax._src.control_variates import moving_avg_baseline
 from optax._src.schedule import constant_schedule
 from optax._src.schedule import cosine_decay_schedule
+from optax._src.schedule import cosine_onecycle_schedule
 from optax._src.schedule import exponential_decay
+from optax._src.schedule import linear_onecycle_schedule
 from optax._src.schedule import piecewise_constant_schedule
+from optax._src.schedule import piecewise_interpolate_schedule
 from optax._src.schedule import polynomial_schedule
 from optax._src.second_order import fisher_diag
 from optax._src.second_order import hessian_diag
@@ -109,6 +112,7 @@ __all__ = (
     "control_delta_method",
     "control_variates_jacobians",
     "cosine_decay_schedule",
+    "cosine_onecycle_schedule",
     "exponential_decay",
     "fisher_diag",
     "flatten",
@@ -119,6 +123,7 @@ __all__ = (
     "identity",
     "InitUpdate",
     "lamb",
+    "linear_onecycle_schedule",
     "measure_valued_jacobians",
     "moving_avg_baseline",
     "multi_normal",
@@ -127,6 +132,7 @@ __all__ = (
     "Params",
     "pathwise_jacobians",
     "piecewise_constant_schedule",
+    "piecewise_interpolate_schedule",
     "polynomial_schedule",
     "rmsprop",
     "scale",

--- a/optax/_src/schedule.py
+++ b/optax/_src/schedule.py
@@ -260,7 +260,7 @@ def piecewise_interpolate_schedule(
 
   return schedule
 
-def linear_onecycle(
+def linear_onecycle_schedule(
     transition_steps: int,
     peak_value: float,
     pct_start: float = 0.3,
@@ -301,7 +301,7 @@ def linear_onecycle(
        transition_steps: 1. / final_div_factor})
 
 
-def cos_onecycle(
+def cosine_onecycle_schedule(
     transition_steps,
     peak_value,
     pct_start=0.3,

--- a/optax/_src/schedule.py
+++ b/optax/_src/schedule.py
@@ -261,13 +261,14 @@ def piecewise_interpolate_schedule(
 
   return schedule
 
+
 def linear_onecycle_schedule(
     transition_steps: int,
     peak_value: float,
     pct_start: float = 0.3,
     pct_final: float = 0.85,
     div_factor: float = 25.0,
-    final_div_factor=1e4):
+    final_div_factor: float = 1e4):
   """Returns a function which implements the onecycle learning rate schedule.
 
   This function uses a linear annealing strategy.
@@ -303,11 +304,11 @@ def linear_onecycle_schedule(
 
 
 def cosine_onecycle_schedule(
-    transition_steps,
-    peak_value,
-    pct_start=0.3,
-    div_factor=25.0,
-    final_div_factor=1e4):
+    transition_steps: int,
+    peak_value: float,
+    pct_start: float = 0.3,
+    div_factor: float = 25.0,
+    final_div_factor: float = 1e4):
   """Returns a function which implements the onecycle learning rate schedule.
 
   This function uses a cosine annealing strategy.
@@ -333,7 +334,7 @@ def cosine_onecycle_schedule(
         '`transition_steps`')
 
   return piecewise_interpolate_schedule(
-    'cosine',
-    peak_value / div_factor,
-    {int(pct_start * transition_steps): div_factor,
-     int(transition_steps): 1. / (div_factor * final_div_factor)})
+      'cosine',
+      peak_value / div_factor,
+      {int(pct_start * transition_steps): div_factor,
+       int(transition_steps): 1. / (div_factor * final_div_factor)})

--- a/optax/_src/schedule.py
+++ b/optax/_src/schedule.py
@@ -214,7 +214,7 @@ def _cos_interpolate(start: float, end: float, pct: float):
   return end + (start-end) / 2.0 * (jnp.cos(jnp.pi * pct) + 1)
 
 
-def _get_branch_schedule(
+def _piecewise_interpolate_schedule_branch(
     interpolate_fn: Callable,
     init_value: float,
     end_value: float,
@@ -223,11 +223,11 @@ def _get_branch_schedule(
   # NOTE: needs to be a seperate function to avoid Python variable look-up from
   # interfering with the intended thresholds and values.
 
-  def branch_schedule(count):
+  def branch(count):
     pct = (count-start_threshold) / float(end_threshold-start_threshold)
     return interpolate_fn(init_value, end_value, pct)
 
-  return branch_schedule
+  return branch
 
 
 def piecewise_interpolate_schedule(
@@ -268,7 +268,7 @@ def piecewise_interpolate_schedule(
     for threshold, scale in sorted(boundaries_and_scales.items()):
       ind = ind + jnp.uint8(count > threshold)
       value = prev_value * scale
-      branches.append(_get_branch_schedule(
+      branches.append(_piecewise_interpolate_schedule_branch(
           interpolate_fn, prev_value, value, prev_threshold, threshold))
       prev_threshold, prev_value = threshold, value
     branches.append(lambda count: prev_value)

--- a/optax/_src/schedule_test.py
+++ b/optax/_src/schedule_test.py
@@ -307,16 +307,16 @@ class PiecewiseInterpolateTest(chex.TestCase):
   @chex.all_variants()
   def test_linear_piecewise(self):
     schedule_fn = self.variant(schedule.piecewise_interpolate_schedule(
-      'linear', 200., {5: 1.5, 10: 0.25}))
+        'linear', 200., {5: 1.5, 10: 0.25}))
     generated_vals = [schedule_fn(step) for step in range(13)]
     expected_vals = [200., 220., 240., 260., 280., 300., 255., 210., 165.,
-                     120., 75.,  75.,  75.]
+                     120., 75., 75., 75.]
     np.testing.assert_allclose(generated_vals, expected_vals, atol=1e-3)
 
   @chex.all_variants()
   def test_cos_piecewise(self):
     schedule_fn = self.variant(schedule.piecewise_interpolate_schedule(
-      'cosine', 400., {5: 1.2, 3: 0.6, 7: 1.}))
+        'cosine', 400., {5: 1.2, 3: 0.6, 7: 1.}))
     generated_vals = [schedule_fn(step) for step in range(9)]
     expected_vals = [400., 360., 280., 240., 264., 288., 288., 288., 288.]
     np.testing.assert_allclose(generated_vals, expected_vals, atol=1e-3)
@@ -324,7 +324,7 @@ class PiecewiseInterpolateTest(chex.TestCase):
   @chex.all_variants()
   def test_empty_dict(self):
     schedule_fn = self.variant(schedule.piecewise_interpolate_schedule(
-      'linear', 13., {}))
+        'linear', 13., {}))
     generated_vals = [schedule_fn(step) for step in range(5)]
     expected_vals = [13., 13., 13., 13., 13.]
     np.testing.assert_allclose(generated_vals, expected_vals, atol=1e-3)
@@ -332,7 +332,7 @@ class PiecewiseInterpolateTest(chex.TestCase):
   @chex.all_variants()
   def test_no_dict(self):
     schedule_fn = self.variant(schedule.piecewise_interpolate_schedule(
-      'cosine', 17.))
+        'cosine', 17.))
     generated_vals = [schedule_fn(step) for step in range(3)]
     expected_vals = [17., 17., 17.]
     np.testing.assert_allclose(generated_vals, expected_vals, atol=1e-3)

--- a/optax/_src/schedule_test.py
+++ b/optax/_src/schedule_test.py
@@ -316,7 +316,7 @@ class PiecewiseInterpolateTest(chex.TestCase):
   @chex.all_variants()
   def test_cos_piecewise(self):
     schedule_fn = self.variant(schedule.piecewise_interpolate_schedule(
-      'cos', 400., {5: 1.2, 3: 0.6, 7: 1.}))
+      'cosine', 400., {5: 1.2, 3: 0.6, 7: 1.}))
     generated_vals = [schedule_fn(step) for step in range(9)]
     expected_vals = [400., 360., 280., 240., 264., 288., 288., 288., 288.]
     np.testing.assert_allclose(generated_vals, expected_vals, atol=1e-3)
@@ -332,7 +332,7 @@ class PiecewiseInterpolateTest(chex.TestCase):
   @chex.all_variants()
   def test_no_dict(self):
     schedule_fn = self.variant(schedule.piecewise_interpolate_schedule(
-      'cos', 17.))
+      'cosine', 17.))
     generated_vals = [schedule_fn(step) for step in range(3)]
     expected_vals = [17., 17., 17.]
     np.testing.assert_allclose(generated_vals, expected_vals, atol=1e-3)
@@ -368,7 +368,7 @@ class OneCycleTest(chex.TestCase):
     np.testing.assert_allclose(generated_vals, expected_vals, atol=1e-3)
 
   @chex.all_variants()
-  def test_cos(self):
+  def test_cosine(self):
     schedule_fn = self.variant(schedule.cosine_onecycle_schedule(
         transition_steps=5,
         peak_value=1000.,

--- a/optax/_src/schedule_test.py
+++ b/optax/_src/schedule_test.py
@@ -354,7 +354,7 @@ class OneCycleTest(chex.TestCase):
 
   @chex.all_variants()
   def test_linear(self):
-    schedule_fn = self.variant(schedule.linear_onecycle(
+    schedule_fn = self.variant(schedule.linear_onecycle_schedule(
         transition_steps=10,
         peak_value=1000,
         pct_start=0.3,
@@ -369,7 +369,7 @@ class OneCycleTest(chex.TestCase):
 
   @chex.all_variants()
   def test_cos(self):
-    schedule_fn = self.variant(schedule.cos_onecycle(
+    schedule_fn = self.variant(schedule.cosine_onecycle_schedule(
         transition_steps=5,
         peak_value=1000.,
         pct_start=0.4,
@@ -382,9 +382,9 @@ class OneCycleTest(chex.TestCase):
 
   def test_nonpositive_transition_steps(self):
     with self.assertRaises(ValueError):
-      schedule.cos_onecycle(transition_steps=0, peak_value=5.)
+      schedule.cosine_onecycle_schedule(transition_steps=0, peak_value=5.)
     with self.assertRaises(ValueError):
-      schedule.linear_onecycle(transition_steps=0, peak_value=5.)
+      schedule.linear_onecycle_schedule(transition_steps=0, peak_value=5.)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #19.

* The parameters/docstrings for `cos_onecycle` and `linear_onecycle` are based on the [PyTorch version](https://pytorch.org/docs/stable/optim.html#torch.optim.lr_scheduler.OneCycleLR). 
* I'm not sure whether to name the methods `*_onecycle` or `*_onecycle_learning_rate`. The referenced paper also proposes a onecycle momentum schedule (implemented by PyTorch as well). If `optax` implements onecycle momentum in the future, it may be confusing.
* I tried to keep the API for `piecewise_interpolate_schedule` as close to `piecewise_constant_schedule` as I could. Please let me know if the arguments should be re-ordered, renamed, etc. In fact, now the `piecewise_constant_schedule` is just a special case of `piecewise_interpolate_schedule` (with a constant interpolation).
* What code format/linter does this library use? I just used [Google's pylintrc](https://google.github.io/styleguide/pyguide.html) and formatted manually, would be nice to include a `setup.cfg` or `.style.yapf` to auto-format code.