### PR TITLE
Implement DPSGD

### DIFF
--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -59,6 +59,8 @@ from optax._src.transform import clip
 from optax._src.transform import clip_by_global_norm
 from optax._src.transform import ClipByGlobalNormState
 from optax._src.transform import ClipState
+from optax._src.transform import differentially_private_aggregate
+from optax._src.transform import DifferentiallyPrivateAggregateState
 from optax._src.transform import global_norm
 from optax._src.transform import GradientTransformation
 from optax._src.transform import identity
@@ -138,6 +140,8 @@ __all__ = (
     "control_variates_jacobians",
     "cosine_decay_schedule",
     "cosine_onecycle_schedule",
+    "differentially_private_aggregate",
+    "DifferentiallyPrivateAggregateState",
     "exponential_decay",
     "fisher_diag",
     "flatten",

--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -19,6 +19,7 @@ from optax._src.alias import adabelief
 from optax._src.alias import adagrad
 from optax._src.alias import adam
 from optax._src.alias import adamw
+from optax._src.alias import dpsgd
 from optax._src.alias import fromage
 from optax._src.alias import lamb
 from optax._src.alias import noisy_sgd
@@ -140,6 +141,7 @@ __all__ = (
     "control_variates_jacobians",
     "cosine_decay_schedule",
     "cosine_onecycle_schedule",
+    "dpsgd",
     "differentially_private_aggregate",
     "DifferentiallyPrivateAggregateState",
     "exponential_decay",

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -156,3 +156,22 @@ def yogi(learning_rate: ScalarOrSchedule,
       transform.scale_by_yogi(b1=b1, b2=b2, eps=eps),
       _scale_by_learning_rate(learning_rate),
   )
+
+
+def dpsgd(learning_rate: ScalarOrSchedule,
+          l2_norm_clip: float,
+          noise_multiplier: float,
+          seed: int,
+          momentum: float = 0.,
+          nesterov: bool = False) -> GradientTransformation:
+  dp_agg = transform.differentially_private_aggregate(
+      l2_norm_clip=l2_norm_clip,
+      noise_multiplier=noise_multiplier,
+      seed=seed)
+  if momentum > 0:
+    return combine.chain(
+      dp_agg,
+      transform.trace(decay=momentum, nesterov=nesterov),
+      _scale_by_learning_rate(learning_rate))
+  else:
+    return combine.chain(dp_agg, _scale_by_learning_rate(learning_rate))

--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -26,9 +26,12 @@ from optax._src import alias
 from optax._src import update
 
 
+_MAX_FLOAT = jnp.finfo(jnp.float32).max
+
+
 class AliasTest(chex.TestCase):
 
-  @parameterized.named_parameters(
+  @parameterized.parameters(
       ('sgd', lambda: alias.sgd(1e-2, 0.0)),
       ('adam', lambda: alias.adam(1e-1)),
       ('adamw', lambda: alias.adamw(1e-1)),
@@ -38,8 +41,9 @@ class AliasTest(chex.TestCase):
       ('adabelief', lambda: alias.adabelief(1e-1)),
       ('radam', lambda: alias.radam(1e-1)),
       ('yogi', lambda: alias.yogi(1.0)),
+      ('dpsgd', lambda: alias.dpsgd(1e-2, _MAX_FLOAT, 0., 0))
   )
-  def test_parabel(self, opt):
+  def test_parabel(self, opt_name, opt):
     opt = opt()
 
     initial_params = jnp.array([-1.0, 10.0, 1.0])
@@ -51,7 +55,9 @@ class AliasTest(chex.TestCase):
 
     @jax.jit
     def step(params, state):
-      updates, state = opt.update(get_updates(params), state, params)
+      updates = get_updates(params)
+      if opt_name == 'dpsgd': updates = updates[None]
+      updates, state = opt.update(updates, state, params)
       params = update.apply_updates(params, updates)
       return params, state
 
@@ -62,7 +68,7 @@ class AliasTest(chex.TestCase):
 
     chex.assert_tree_all_close(params, final_params, rtol=1e-2, atol=1e-2)
 
-  @parameterized.named_parameters(
+  @parameterized.parameters(
       ('sgd', lambda: alias.sgd(2e-3, 0.2)),
       ('adam', lambda: alias.adam(1e-1)),
       ('adamw', lambda: alias.adamw(1e-1)),
@@ -72,8 +78,9 @@ class AliasTest(chex.TestCase):
       ('adabelief', lambda: alias.adabelief(1e-1)),
       ('radam', lambda: alias.radam(1e-3)),
       ('yogi', lambda: alias.yogi(1.0)),
+      ('dpsgd', lambda: alias.dpsgd(2e-3, _MAX_FLOAT, 0., 0, 0.2))
   )
-  def test_rosenbrock(self, opt):
+  def test_rosenbrock(self, opt_name, opt):
     opt = opt()
 
     a = 1.0
@@ -87,7 +94,9 @@ class AliasTest(chex.TestCase):
 
     @jax.jit
     def step(params, state):
-      updates, state = opt.update(get_updates(params), state, params)
+      updates = get_updates(params)
+      if opt_name == 'dpsgd': updates = updates[None]
+      updates, state = opt.update(updates, state, params)
       params = update.apply_updates(params, updates)
       return params, state
 

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -16,6 +16,8 @@
 """Gradient transformations."""
 
 from typing import Any, Callable, NamedTuple, Optional, Sequence, Tuple, Union
+from functools import partial
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -893,3 +895,65 @@ def zero_nans() -> GradientTransformation:
     return updates, opt_state
 
   return GradientTransformation(init=init_fn, update=update_fn)
+
+
+class DifferentiallyPrivateAggregateState(OptState):
+  """State containing PRNGKey for differentially_private_aggregate."""
+  rng_key: jnp.array
+
+
+@partial(jax.vmap, in_axes=(0, None))
+def _clip_per_example_grads(grads_flat: Sequence[chex.Array],
+                            l2_norm_clip: float):
+  global_grad_norm = jnp.linalg.norm([
+      jnp.linalg.norm(g.ravel()) for g in grads_flat])
+  divisor = jnp.maximum(global_grad_norm / l2_norm_clip, 1.0)
+  return [g/divisor for g in grads_flat]
+
+
+def differentially_private_aggregate(l2_norm_clip: float,
+                                     noise_multiplier: float,
+                                     seed: int) -> GradientTransformation:
+  """Aggregates gradients based on the DPSGD algorithm.
+
+  Unlike other transforms, `differentially_private_aggregate` expects the input
+  updates to have a batch dimension in the 0th axis. That is, this function
+  expects per-example gradients as input (which are easy to obtain in JAX:
+  simply use `vmap(grad(fn))` instead of `grad(fn)`). It can still be
+  composed with other transformations as long as it is the first in the chain.
+
+  References:
+    [Song et al, 2013](https://cseweb.ucsd.edu/~kamalika/pubs/scs13.pdf)
+
+  Args:
+    l2_norm_clip: maximum L2 norm of the per-example gradients.
+    noise_multiplier: ratio of standard deviation to the clipping norm.
+    seed: initial seed used for the jax.random.PRNGKey
+
+  Returns:
+    A `GradientTransformation`.
+  """
+  noise_std = l2_norm_clip * noise_multiplier
+
+  def init_fn(_):
+    return DifferentiallyPrivateAggregateState(rng_key=jax.random.PRNGKey(seed))
+
+  def update_fn(updates, state, params=None):
+    grads_flat, grads_treedef = jax.tree_flatten(updates)
+
+    if params is not None and any(g.shape[1:] != p.shape
+        for g, p in zip(grads_flat, jax.tree_leaves(params))):
+      raise ValueError(
+          'Unlike other transforms, `differentially_private_aggregate` expects'
+          ' `updates` to have a batch dimension in the 0th axis. That is, this'
+          ' function expects per-example gradients as input.')
+
+    new_key, *rngs = jax.random.split(state.rng_key, len(grads_flat)+1)
+    clipped_grads_flat = _clip_per_example_grads(grads_flat, l2_norm_clip)
+    updates_flat = [
+        (g.sum(0) + noise_std * jax.random.normal(r, g.shape[1:])) / g.shape[0]
+        for r, g in zip(rngs, clipped_grads_flat)]
+    return (jax.tree_unflatten(grads_treedef, updates_flat),
+            DifferentiallyPrivateAggregateState(rng_key=new_key))
+
+  return GradientTransformation(init_fn, update_fn)

--- a/optax/_src/transform_test.py
+++ b/optax/_src/transform_test.py
@@ -232,5 +232,89 @@ class TransformTest(parameterized.TestCase):
     chex.assert_tree_all_equal_comparator(equality_comp, updates, grads)
 
 
+class DifferentiallyPrivateAggregateTest(parameterized.TestCase):
+
+  def setUp(self):
+    super(DifferentiallyPrivateAggregateTest, self).setUp()
+    self.batch_size = 8
+    self.params = {'key_a': (jnp.zeros((2, 3, 4)), jnp.zeros([])),
+                   'key_b': jnp.zeros((6, 7))}
+    # Example `i`'s grads are full of `i`s. Important to include 0 to ensure
+    # there are no divisons by 0 (e.g. in norm clipping)
+    a = jnp.arange(self.batch_size)
+    self.per_eg_grads = jax.tree_map(
+        lambda p: jnp.moveaxis(a * jnp.ones(p.shape+(self.batch_size,)), -1, 0),
+        self.params)
+
+  @chex.all_variants
+  def test_no_privacy(self):
+    """l2_norm_clip=MAX_FLOAT32 and noise_multiplier=0 should recover SGD."""
+    dp_agg = transform.differentially_private_aggregate(
+        l2_norm_clip=jnp.finfo(jnp.float32).max,
+        noise_multiplier=0.,
+        seed=0)
+    state = dp_agg.init(self.params)
+    update_fn = self.variant(dp_agg.update)
+    mean_grads = jax.tree_map(lambda g: g.mean(0), self.per_eg_grads)
+
+    for _ in range(3):
+      updates, state = update_fn(self.per_eg_grads, state)
+      chex.assert_tree_all_close(updates, mean_grads)
+
+  @chex.all_variants
+  @parameterized.parameters(0.5, 10.0, 20.0, 40.0, 80.0)
+  def test_clipping_norm(self, l2_norm_clip):
+    dp_agg = transform.differentially_private_aggregate(
+        l2_norm_clip=l2_norm_clip,
+        noise_multiplier=0.,
+        seed=42)
+    state = dp_agg.init(self.params)
+    update_fn = self.variant(dp_agg.update)
+
+    # Shape of the three arrays below is (self.batch_size, )
+    norms = [jnp.linalg.norm(g.reshape(self.batch_size, -1), axis=1)
+             for g in jax.tree_leaves(self.per_eg_grads)]
+    global_norms = jnp.linalg.norm(jnp.stack(norms), axis=0)
+    divisors = jnp.maximum(global_norms / l2_norm_clip, 1.)
+    # Since the values of all the parameters are the same within each example,
+    # we can easily compute what the values should be:
+    expected_val = jnp.mean(jnp.arange(self.batch_size) / divisors)
+    expected_tree = jax.tree_map(
+        lambda p: jnp.broadcast_to(expected_val, p.shape), self.params)
+
+    for _ in range(3):
+      updates, state = update_fn(self.per_eg_grads, state, self.params)
+      chex.assert_tree_all_close(updates, expected_tree)
+
+  @chex.all_variants
+  @parameterized.parameters((3.0, 2.0), (1.0, 5.0), (100.0, 4.0), (1.0, 90.0))
+  def test_noise_multiplier(self, l2_norm_clip, noise_multiplier):
+    """Standard dev. of noise should be l2_norm_clip * noise_multiplier."""
+    dp_agg = transform.differentially_private_aggregate(
+        l2_norm_clip=l2_norm_clip,
+        noise_multiplier=noise_multiplier,
+        seed=1337)
+    state = dp_agg.init(None)
+    update_fn = self.variant(dp_agg.update)
+    expected_std = l2_norm_clip * noise_multiplier
+
+    grads = [jnp.ones((1, 100, 100))]  # batch size 1
+    for _ in range(3):
+      updates, state = update_fn(grads, state)
+      chex.assert_tree_all_close(expected_std,
+                                 jnp.std(updates[0]),
+                                 atol=0.1 * expected_std)
+
+  def test_aggregated_updates_as_input_fails(self):
+    """Expect per-example gradients as input to this transform."""
+    dp_agg = transform.differentially_private_aggregate(l2_norm_clip=0.1,
+                                                        noise_multiplier=1.1,
+                                                        seed=2021)
+    state = dp_agg.init(self.params)
+    mean_grads = jax.tree_map(lambda g: g.mean(0), self.per_eg_grads)
+    with self.assertRaises(ValueError):
+      dp_agg.update(mean_grads, state, self.params)
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Closes #50 

The unit tests are based on [TensorFlow Privacy's](https://github.com/tensorflow/privacy/blob/master/tensorflow_privacy/privacy/optimizers/dp_optimizer_vectorized.py). I verified the performance is similar to the JAX demo [here](https://colab.research.google.com/drive/1JnNAC2BHYJitUCSIIw1TbOSt7paysUO-?usp=sharing).

Some questions:
- For rosenbrock/parabel, I tested dpsgd by setting the norm clipping to `jnp.finfo(jnp.float32).max` and noise multiplier to 0, which makes it identical to SGD (so not really a good test :P). Do I just tune DPSGD to work on these problems with some arbitrary noise/clipping?
- Since all the transform functions are verbs (e.g. _scale_ by adam), I called the dpsgd function `differentially_private_aggregate`. The name sounds awkward to me, I'd appreciate feedback/suggestions on it.
- The loss and accuracy are pretty close to the JAX exemplar implementation, (0.18 vs. 0.22 and 96.61% vs. 96.16%), but is this close enough? Since there is randomness in this algorithm, I'm not sure if we can expect much closer.
- In the implementation, I check that the update shapes passed by the user have the required batch dimension using the shapes of `params` ([here](https://github.com/n2cholas/optax/blob/5b23f42075a34a9127764d2444b40e5173afe84d/optax/_src/transform.py#L941-L949)). Should I make `params` a required argument to `update_fn`? Or no, since the algorithm doesn't technically _need_ params? Or should I remove the check altogether?

Any other feedback would be appreciated!