### PR TITLE
Implement DPSGD example.

### DIFF
--- a/examples/differentially_private_sgd.py
+++ b/examples/differentially_private_sgd.py
@@ -66,15 +66,11 @@ import warnings
 
 from absl import app
 from absl import flags
-
-import jax
-import jax.numpy as jnp
-from jax.experimental import stax
-import optax
-
 import datasets
-
-# https://github.com/tensorflow/privacy
+import jax
+from jax.experimental import stax
+import jax.numpy as jnp
+import optax
 from tensorflow_privacy.privacy.analysis.rdp_accountant import compute_rdp
 from tensorflow_privacy.privacy.analysis.rdp_accountant import get_privacy_spent
 

--- a/examples/dpsgd_example.py
+++ b/examples/dpsgd_example.py
@@ -1,0 +1,185 @@
+# Copyright 2021 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JAX efficiently trains a differentially private conv net on MNIST.
+This script contains a JAX implementation of Differentially Private Stochastic
+Gradient Descent (https://arxiv.org/abs/1607.00133). DPSGD requires clipping
+the per-example parameter gradients, which is non-trivial to implement
+efficiently for convolutional neural networks.  The JAX XLA compiler shines in
+this setting by optimizing the minibatch-vectorized computation for
+convolutional architectures. Train time takes a few seconds per epoch on a
+commodity GPU.
+This code depends on tensorflow_privacy (https://github.com/tensorflow/privacy)
+  Install instructions:
+    $ pip install tensorflow git+https://github.com/tensorflow/privacy.git
+The results match those in the reference TensorFlow baseline implementation:
+  https://github.com/tensorflow/privacy/tree/master/tutorials
+Example invocations:
+  # this non-private baseline should get ~99% acc
+  python -m examples.differentially_private_sgd \
+    --dpsgd=False \
+    --learning_rate=.1 \
+    --epochs=20 \
+   this private baseline should get ~95% acc
+  python -m examples.differentially_private_sgd \
+   --dpsgd=True \
+   --noise_multiplier=1.3 \
+   --l2_norm_clip=1.5 \
+   --epochs=15 \
+   --learning_rate=.25 \
+  # this private baseline should get ~96.6% acc
+  python -m examples.differentially_private_sgd \
+   --dpsgd=True \
+   --noise_multiplier=1.1 \
+   --l2_norm_clip=1.0 \
+   --epochs=60 \
+   --learning_rate=.15 \
+  # this private baseline should get ~97% acc
+  python -m examples.differentially_private_sgd \
+   --dpsgd=True \
+   --noise_multiplier=0.7 \
+   --l2_norm_clip=1.5 \
+   --epochs=45 \
+   --learning_rate=.25 \
+"""
+
+import time
+import warnings
+
+from absl import app
+from absl import flags
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import stax
+import optax
+
+import datasets
+
+# https://github.com/tensorflow/privacy
+from tensorflow_privacy.privacy.analysis.rdp_accountant import compute_rdp
+from tensorflow_privacy.privacy.analysis.rdp_accountant import get_privacy_spent
+
+NUM_EXAMPLES = 60_000
+FLAGS = flags.FLAGS
+
+flags.DEFINE_boolean(
+    'dpsgd', True, 'If True, train with DP-SGD. If False, '
+    'train with vanilla SGD.')
+flags.DEFINE_float('learning_rate', .15, 'Learning rate for training')
+flags.DEFINE_float('noise_multiplier', 1.1,
+                   'Ratio of the standard deviation to the clipping norm')
+flags.DEFINE_float('l2_norm_clip', 1.0, 'Clipping norm')
+flags.DEFINE_integer('batch_size', 256, 'Batch size')
+flags.DEFINE_integer('epochs', 60, 'Number of epochs')
+flags.DEFINE_integer('seed', 0, 'Seed for jax PRNG')
+flags.DEFINE_integer(
+    'microbatches', None, 'Number of microbatches '
+    '(must evenly divide batch_size)')
+flags.DEFINE_string('model_dir', None, 'Model directory')
+flags.DEFINE_float('delta', 1e-5, 'Target delta used to compute privacy spent.')
+
+
+init_random_params, predict = stax.serial(
+    stax.Conv(16, (8, 8), padding='SAME', strides=(2, 2)),
+    stax.Relu,
+    stax.MaxPool((2, 2), (1, 1)),
+    stax.Conv(32, (4, 4), padding='VALID', strides=(2, 2)),
+    stax.Relu,
+    stax.MaxPool((2, 2), (1, 1)),
+    stax.Flatten,
+    stax.Dense(32),
+    stax.Relu,
+    stax.Dense(10),
+)
+
+
+def compute_epsilon(steps, target_delta=1e-5):
+  if NUM_EXAMPLES * target_delta > 1.:
+    warnings.warn('Your delta might be too high.')
+  q = FLAGS.batch_size / float(NUM_EXAMPLES)
+  orders = list(jnp.linspace(1.1, 10.9, 99)) + list(range(11, 64))
+  rdp_const = compute_rdp(q, FLAGS.noise_multiplier, steps, orders)
+  eps, _, _ = get_privacy_spent(orders, rdp_const, target_delta=target_delta)
+  return eps
+
+
+def loss_fn(params, batch):
+  logits = predict(params, batch['image'])
+  return optax.softmax_cross_entropy(logits, batch['label']).mean(), logits
+
+
+@jax.jit
+def test_step(params, batch):
+  loss, logits = loss_fn(params, batch)
+  accuracy = (logits.argmax(1) == batch['label'].argmax(1)).mean()
+  return loss, accuracy * 100
+
+
+def main(_):
+  train_dataset = datasets.load_image_dataset('mnist', FLAGS.batch_size)
+  train_dataset = list(train_dataset.as_numpy_iterator())
+  test_dataset = datasets.load_image_dataset('mnist', NUM_EXAMPLES,
+                                             datasets.Split.TEST)
+  full_test_batch = next(test_dataset.as_numpy_iterator())
+
+  if FLAGS.dpsgd:
+    tx = optax.dpsgd(learning_rate=FLAGS.learning_rate,
+                     l2_norm_clip=FLAGS.l2_norm_clip,
+                     noise_multiplier=FLAGS.noise_multiplier,
+                     seed=FLAGS.seed)
+  else:
+    tx = optax.sgd(learning_rate=FLAGS.learning_rate)
+
+  @jax.jit
+  def train_step(params, opt_state, batch):
+    grad_fn = jax.grad(loss_fn, has_aux=True)
+    if FLAGS.dpsgd:
+      # Insert dummy dimension in axis 1 to use jax.vmap over the batch
+      batch = jax.tree_map(lambda x: x[:, None], batch)
+      # Use jax.vmap across the batch to extract per-example gradients
+      grad_fn = jax.vmap(grad_fn, in_axes=(None, 0))
+
+    grads, _ = grad_fn(params, batch)
+    updates, new_opt_state = tx.update(grads, opt_state, params)
+    new_params = optax.apply_updates(params, updates)
+    return new_params, new_opt_state
+
+  key = jax.random.PRNGKey(FLAGS.seed)
+  _, params = init_random_params(key, (-1, 28, 28, 1))
+  opt_state = tx.init(params)
+
+  print('\nStarting training...')
+  for epoch in range(1, FLAGS.epochs + 1):
+    start_time = time.time()
+    for batch in train_dataset:
+      params, opt_state = train_step(params, opt_state, batch)
+    epoch_time = time.time() - start_time
+    print(f'Epoch {epoch} in {epoch_time:0.2f} seconds.')
+
+    # Evaluate test accuracy
+    test_loss, test_acc = test_step(params, full_test_batch)
+    print(f'Test Loss: {test_loss:.2f}  Test Accuracy (%): {test_acc:.2f}).')
+
+    # Determine privacy loss so far
+    if FLAGS.dpsgd:
+      steps_per_epoch = NUM_EXAMPLES // FLAGS.batch_size
+      eps = compute_epsilon(epoch * steps_per_epoch, FLAGS.delta)
+      print(f'For delta={FLAGS.delta:.0e}, the current epsilon is: {eps:.2f}.')
+    else:
+      print('Trained with vanilla non-private SGD optimizer.')
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/requirements/requirements-examples.txt
+++ b/requirements/requirements-examples.txt
@@ -1,1 +1,4 @@
 dm-haiku>=0.0.3
+tensorflow-datasets>=4.2.0
+tensorflow>=2.4.0
+tensorflow_privacy>=0.5.1


### PR DESCRIPTION
DPSGD example as requested in #53. Verified the accuracies are close with a few seeds [here](https://colab.research.google.com/drive/107SrfBIyZdD9ES67xEvuNy0J8kUEirl_?usp=sharing). This is based on the [`differentially_private_sgd.py`](https://github.com/google/jax/blob/master/examples/differentially_private_sgd.py) example in the JAX repo, but refactored to better match Optax's style.

Questions:
1. How do I run these examples? I couldn't get the `from optax.examples import datasets` import to work when running it via `python3 dpsgd_example.py`
2. Is the name ok? The JAX example named it `differentially_private_sgd.py` I used `dpsgd_example.py` because `differentially_private_sgd_example.py` is kind of long.
3. The default seed of 0 results in a slightly lower accuracy than the reported (just like we saw in #53), should I switch the default seed?
4. Should I create a `requirements.txt` specifically for this example? Or is the comment in the file enough (that specifies how to install `tensorflow_privacy`.

Additional questions/concerns listed as review comments below.

cc: @mtthss 