### PR TITLE
Add Fromage optimizer description, reference, arg doc strings to Optax

### DIFF
--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -194,7 +194,9 @@ def fromage(
 
   Args:
     learning_rate: this is a fixed global scaling factor.
-    min_norm: a weight decay hyperparameter.
+    min_norm: a minimum value that the norm of the gradients updates and the
+    norm of the layer parameters can be clipped to to avoid dividing by zero
+    when computing the trust ratio (as in the LARS paper).
 
   Returns:
     the corresponding `GradientTransformation`.

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -191,11 +191,11 @@ def fromage(
 
   References:
     [Bernstein et al, 2020](https://arxiv.org/abs/2002.03432)
-  
+
   Args:
     learning_rate: this is a fixed global scaling factor.
     min_norm: a weight decay hyperparameter.
-  
+
   Returns:
     the corresponding `GradientTransformation`.
   """

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -181,7 +181,6 @@ def fromage(
     learning_rate: float,
     min_norm: float = 1e-6
 ) -> base.GradientTransformation:
-  mult = 1 / jnp.sqrt(1 + learning_rate ** 2)
   """The Frobenius matched gradient descent (Fromage) optimiser.
 
   Fromage is a learning algorithm that does not require learning rate tuning.
@@ -197,6 +196,7 @@ def fromage(
     learning_rate: this is a fixed global scaling factor.
     min_norm: a weight decay hyperparameter.
   """
+  mult = 1 / jnp.sqrt(1 + learning_rate ** 2)
   return combine.chain(
       transform.scale_by_trust_ratio(min_norm),
       _scale_by_learning_rate(learning_rate * mult),

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -194,7 +194,7 @@ def fromage(
 
   Args:
     learning_rate: this is a fixed global scaling factor.
-    min_norm: a minimum value that the norm of the gradients updates and the
+    min_norm: a minimum value that the norm of the gradient updates and the
     norm of the layer parameters can be clipped to to avoid dividing by zero
     when computing the trust ratio (as in the LARS paper).
 

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -195,6 +195,9 @@ def fromage(
   Args:
     learning_rate: this is a fixed global scaling factor.
     min_norm: a weight decay hyperparameter.
+  
+  Returns:
+    the corresponding `GradientTransformation`.
   """
   mult = 1 / jnp.sqrt(1 + learning_rate ** 2)
   return combine.chain(

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -182,6 +182,21 @@ def fromage(
     min_norm: float = 1e-6
 ) -> base.GradientTransformation:
   mult = 1 / jnp.sqrt(1 + learning_rate ** 2)
+  """The Frobenius matched gradient descent (Fromage) optimiser.
+
+  Fromage is a learning algorithm that does not require learning rate tuning.
+  The optimiser is based on modelling neural network gradients via deep relative
+  trust (a distance function on deep neural networks). Fromage is similar to the
+  LARS optimiser and can work on a range of standard neural network benchmarks,
+  such as natural language Transformers and generative adversarial networks.
+
+  References:
+    [Bernstein et al, 2020](https://arxiv.org/abs/2002.03432)
+  
+  Args:
+    learning_rate: this is a fixed global scaling factor.
+    min_norm: a weight decay hyperparameter.
+  """
   return combine.chain(
       transform.scale_by_trust_ratio(min_norm),
       _scale_by_learning_rate(learning_rate * mult),


### PR DESCRIPTION
This PR adds a short description, a paper reference, and arg doc strings to the Fromage optimizer in Optax, since it was not documented. Related to https://github.com/deepmind/optax/pull/71 by @mtthss

```
  """The Frobenius matched gradient descent (Fromage) optimiser.

  Fromage is a learning algorithm that does not require learning rate tuning.
  The optimiser is based on modelling neural network gradients via deep relative
  trust (a distance function on deep neural networks). Fromage is similar to the
  LARS optimiser and can work on a range of standard neural network benchmarks,
  such as natural language Transformers and generative adversarial networks.

  References:
    [Bernstein et al, 2020](https://arxiv.org/abs/2002.03432)
```

(Note: Having studied the "On the distance between two neural networks and the stability of learning" paper, I assume the `min_norm` arg is the weight decay coefficient but this may not be correct, since the param was for LARS, SGD and other (?) optimizers, and Fromage may not need it (?). @mtthss LMK what `min_norm` is and I'll correct this.)

Update: based on the LARS paper https://arxiv.org/pdf/1708.03888.pdf

```
    min_norm: a minimum value that the norm of the gradient updates and the
    norm of the layer parameters can be clipped to to avoid dividing by zero
    when computing the trust ratio (as in the LARS paper).
```
