### PR TITLE
Disable RMSprop reference pylint `max-line-length`, fix lecture reference link

### DIFF
--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -342,7 +342,7 @@ def rmsprop(
   optimiser that can be used to switch between several of these variants.
 
   References:
-    Tieleman and Hinton, 2012: www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf
+    Tieleman and Hinton, 2012: http://www.cs.toronto.edu/~hinton/coursera/lecture6/lec6.pdf
     Graves, 2013: https://arxiv.org/abs/1308.0850
 
   Args:

--- a/optax/_src/alias.py
+++ b/optax/_src/alias.py
@@ -323,7 +323,7 @@ def radam(
       _scale_by_learning_rate(learning_rate),
   )
 
-
+# pylint: disable=line-too-long
 def rmsprop(
     learning_rate: ScalarOrSchedule,
     decay: float = 0.9,
@@ -342,8 +342,7 @@ def rmsprop(
   optimiser that can be used to switch between several of these variants.
 
   References:
-    Tieleman and Hinton, 2012:
-        www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf
+    Tieleman and Hinton, 2012: www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf
     Graves, 2013: https://arxiv.org/abs/1308.0850
 
   Args:
@@ -377,7 +376,7 @@ def rmsprop(
       (transform.trace(decay=momentum, nesterov=nesterov)
        if momentum is not None else base.identity())
   )
-
+# pylint: enable=line-too-long
 
 def sgd(
     learning_rate: ScalarOrSchedule,


### PR DESCRIPTION
Follow up to PR https://github.com/deepmind/optax/pull/118, Issue https://github.com/deepmind/optax/issues/113.

This PR proposes a possible fix that should hopefully work on multiple lines, since the URL link is inside a doc string.

```diff
+ # pylint: disable=line-too-long
def rmsprop(
    learning_rate: ScalarOrSchedule,
    decay: float = 0.9,
  """A flexible RMSProp optimiser.
  ...
  References:
-     Tieleman and Hinton, 2012:
-         www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf
[UPDATE: this link stopped working]    Tieleman and Hinton, 2012: www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf
+     Tieleman and Hinton, 2012: http://www.cs.toronto.edu/~hinton/coursera/lecture6/lec6.pdf
  ...
  Returns:
    the corresponding `GradientTransformation`.
  """
  ...
      (transform.trace(decay=momentum, nesterov=nesterov)
       if momentum is not None else base.identity())
  )
+ # pylint: enable=line-too-long