### PR TITLE
Fix codeblock rendering in docstrings.

### DIFF
--- a/optax/_src/schedule.py
+++ b/optax/_src/schedule.py
@@ -515,39 +515,35 @@ def inject_hyperparams(
   hyperparameters. You may only schedule numeric hyperparameters (i.e. boolean
   flags cannot be scheduled).
 
-  For example, to use `scale_by_adam` with a piecewise linear
-  schedule for beta_1 and constant for beta_2:
+  For example, to use ``scale_by_adam`` with a piecewise linear
+  schedule for beta_1 and constant for beta_2::
 
-  ```
-  scheduled_adam = optax.inject_hyperparams(optax.scale_by_adam)(
-      b1=optax.piecewise_linear_schedule(...),
-      b2=0.99)
-  ```
+    scheduled_adam = optax.inject_hyperparams(optax.scale_by_adam)(
+        b1=optax.piecewise_linear_schedule(...),
+        b2=0.99)
 
   You may manually change numeric hyperparameters that were not scheduled
-  through the `hyperparams` dict in the InjectHyperparamState:
+  through the ``hyperparams`` dict in the ``InjectHyperparamState``::
 
-  ```
-  state = scheduled_adam.init(params)
-  updates, state = scheduled_adam.update(grads, state)
-  state.hyperparams['b2'] = 0.95
-  updates, state = scheduled_adam.update(updates, state)  # uses b2 = 0.95
-  ```
+    state = scheduled_adam.init(params)
+    updates, state = scheduled_adam.update(grads, state)
+    state.hyperparams['b2'] = 0.95
+    updates, state = scheduled_adam.update(updates, state)  # uses b2 = 0.95
 
   Manually overriding scheduled hyperparameters will have no effect (e.g.
-  in the code sample above, you cannot manually adjust `b1`).
+  in the code sample above, you cannot manually adjust ``b1``).
 
   Args:
     inner_factory: a function that returns the inner
-      `optax.GradientTransformation` given the hyperparameters.
+      ``optax.GradientTransformation`` given the hyperparameters.
     static_args: a string or iterable of strings specifying which
       callable parameters are not schedules. inject_hyperparams treats all
       callables as schedules by default, so if a hyperparameter is a
       non-schedule callable, you must specify that using this argument.
 
   Returns:
-    A callable that returns a `optax.GradientTransformation`. This callable
-    accepts the same arguments as `inner_factor`, except you may provide
+    A callable that returns a ``optax.GradientTransformation``. This callable
+    accepts the same arguments as ``inner_factory``, except you may provide
     schedules in place of the constant arguments.
   """
   static_args = ({static_args} if isinstance(static_args, str) else

--- a/optax/_src/wrappers.py
+++ b/optax/_src/wrappers.py
@@ -282,32 +282,28 @@ def masked(
   For example, it is common to skip weight decay for BatchNorm scale and all
   bias parameters. In many networks, these are the only parameters with only
   one dimension. So, you may create a mask function to mask these out as
-  follows:
+  follows::
 
-  ```
-  mask_fn = lambda p: jax.tree_util.tree_map(lambda x: x.ndim != 1, p)
-  custom_weight_decay = optax.masked(optax.add_decayed_weights(0.001), mask_fn)
-  ```
+    mask_fn = lambda p: jax.tree_map(lambda x: x.ndim != 1, p)
+    weight_decay = optax.masked(optax.add_decayed_weights(0.001), mask_fn)
 
-  You may alternatively create the mask pytree upfront:
+  You may alternatively create the mask pytree upfront::
 
-  ```
-  mask = jax.tree_util.tree_map(lambda x: x.ndim != 1, params)
-  custom_weight_decay = optax.masked(optax.add_decayed_weights(0.001), mask)
-  ```
+    mask = jax.tree_map(lambda x: x.ndim != 1, params)
+    weight_decay = optax.masked(optax.add_decayed_weights(0.001), mask)
 
-  For the `inner` transform, state will only be stored for the parameters that
-  have a mask value of `True`.
+  For the ``inner`` transform, state will only be stored for the parameters that
+  have a mask value of ``True``.
 
   Args:
     inner: Inner transformation to mask.
     mask: a PyTree with same structure as (or a prefix of) the params PyTree,
       or a Callable that returns such a pytree given the params/updates.
-      The leaves should be booleans, `True` for leaves/subtrees you want to
-      apply the transformation to, and `False` for those you want to skip.
+      The leaves should be booleans, ``True`` for leaves/subtrees you want to
+      apply the transformation to, and ``False`` for those you want to skip.
 
   Returns:
-    New GradientTransformation wrapping `inner`.
+    New GradientTransformation wrapping ``inner``.
   """
   def init_fn(params):
     flat_mask, treedef = tree_flatten(mask(params) if callable(mask) else mask)


### PR DESCRIPTION
This ensures the code snippets in the docstrings for [`inject_hyperparams`](https://optax.readthedocs.io/en/latest/api.html#optax.inject_hyperparams) and [`masked`](https://optax.readthedocs.io/en/latest/api.html#optax.masked) render correctly on the readthedocs page.

Also, readthedocs treats the backtick (`) as italics, so you need double backticks to have inline code font (unlike in Markdown).