### PR TITLE
Implement `split_complex`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -362,6 +362,8 @@ Optimizer Wrappers
     MaybeUpdateState
     MultiSteps
     MultiStepsState
+    split_complex
+    SplitComplexState
 
 
 Apply if Finite
@@ -416,6 +418,15 @@ Multi-step Update
    :members:
 
 .. autoclass:: MultiStepsState
+   :members:
+
+
+Split Complex
+~~~~~~~~~~~~~~
+
+.. autofunction::  split_complex
+
+.. autoclass::  SplitComplexState
    :members:
 
 

--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -49,6 +49,8 @@ from optax._src.clipping import ClipState
 from optax._src.combine import chain
 from optax._src.combine import multi_transform
 from optax._src.combine import MultiTransformState
+from optax._src.complex_valued import split_complex
+from optax._src.complex_valued import SplitComplexState
 from optax._src.constrain import keep_params_nonnegative
 from optax._src.constrain import NonNegativeParamsState
 from optax._src.constrain import zero_nans

--- a/optax/_src/complex_valued.py
+++ b/optax/_src/complex_valued.py
@@ -1,0 +1,92 @@
+# Copyright 2019 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Complex-valued optimization."""
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+
+from optax._src import base
+
+
+@jax.tree_util.register_pytree_node_class
+@dataclass
+class RealPair:
+  """A pair of real arrays split from a complex array."""
+  real: jnp.array
+  imag: jnp.array
+
+  def tree_flatten(self):
+    return ((self.real, self.imag), None)
+
+  @classmethod
+  def tree_unflatten(cls, _, children):
+    return cls(*children)
+
+
+def _is_real_pair(x):
+  return isinstance(x, RealPair)
+
+
+def _complex_to_real_pair(x):
+  if jnp.iscomplexobj(x):
+    return RealPair(x.real, x.imag)
+  else:
+    return x
+
+
+def _real_pair_to_complex(x):
+  if _is_real_pair(x):
+    return x.real + x.imag * 1j
+  else:
+    return x
+
+
+class SplitComplexState(NamedTuple):
+  """Maintains the inner transformation state for `split_complex`."""
+  inner_state: base.OptState
+
+
+def split_complex(
+    inner: base.GradientTransformation
+) -> base.GradientTransformation:
+  """Splits the complex parameters into pairs of real parameters before sending
+  them to the inner transformation, and merges the pairs of real updates into
+  complex updates afterward.
+
+  Args:
+    inner: the inner transformation.
+
+  Returns:
+    An `optax.GradientTransformation`.
+  """
+
+  def init_fn(params):
+    params = jax.tree_map(_complex_to_real_pair, params)
+    inner_state = inner.init(params)
+    return SplitComplexState(inner_state)
+
+  def update_fn(updates, state, params=None):
+    inner_state = state.inner_state
+    updates = jax.tree_map(_complex_to_real_pair, updates)
+    params = jax.tree_map(_complex_to_real_pair, params)
+    updates, inner_state = inner.update(updates, inner_state, params)
+    updates = jax.tree_map(
+        _real_pair_to_complex, updates, is_leaf=_is_real_pair)
+    return updates, SplitComplexState(inner_state)
+
+  return base.GradientTransformation(init_fn, update_fn)

--- a/optax/_src/complex_valued_test.py
+++ b/optax/_src/complex_valued_test.py
@@ -1,0 +1,73 @@
+# Copyright 2019 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for `complex_valued.py`."""
+
+from absl.testing import absltest
+
+import chex
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from optax._src import alias
+from optax._src import complex_valued
+from optax._src import update
+
+
+class ComplexValuedTest(chex.TestCase):
+
+  def test_split_complex(self):
+
+    # Complex-to-real loss function
+    def loss_fun_c2r(z):
+      return (z.conj() * z).real.sum()
+
+    # Real-to-real loss function
+    def loss_fun_r2r(params):
+      x, y = params
+      return loss_fun_c2r(x + y * 1j)
+
+    def do_update(loss_fun, optimizer, params, opt_state):
+      loss, grads = jax.value_and_grad(loss_fun)(params)
+      # Complex gradients need to be conjugated before being added to parameters
+      grads = jax.tree_map(lambda x: x.conj(), grads)
+      updates, opt_state = optimizer.update(grads, opt_state)
+      params = update.apply_updates(params, updates)
+      return loss, grads, params, opt_state
+
+    # Random initial parameters
+    x = jnp.asarray(np.random.randn(3))
+    y = jnp.asarray(np.random.randn(3))
+    z = x + y * 1j
+
+    optimizer = alias.adam(learning_rate=1e-2)
+    optimizer_complex = complex_valued.split_complex(optimizer)
+    opt_state = optimizer.init((x, y))
+    opt_state_complex = optimizer_complex.init(z)
+
+    # Check that the loss, the gradients, and the parameters are the same for
+    # R2R and C2R loss functions in each step
+    for _ in range(3):
+      loss, (gx, gy), (x, y), opt_state = do_update(
+          loss_fun_r2r, optimizer, (x, y), opt_state)
+      loss_complex, gz, z, opt_state_complex = do_update(
+          loss_fun_c2r, optimizer_complex, z, opt_state_complex)
+      np.testing.assert_allclose(loss, loss_complex)
+      np.testing.assert_allclose(gx + gy * 1j, gz)
+      np.testing.assert_allclose(x + y * 1j, z)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
As proposed in #196, it is an optimizer wrapper that splits the complex parameters into pairs of real parameters before sending them to the `update` of the wrapped optimizer, and merges the pairs of real updates into complex updates afterward.