### PR TITLE
Fix Yogi optimizer

### DIFF
--- a/optax/_src/alias_test.py
+++ b/optax/_src/alias_test.py
@@ -77,7 +77,7 @@ class AliasTest(chex.TestCase):
       ('adabelief', lambda: alias.adabelief(1e-1)),
       ('radam', lambda: alias.radam(1e-3)),
       ('sm3', lambda: alias.sm3(1.0)),
-      ('yogi', lambda: alias.yogi(1.0)),
+      ('yogi', lambda: alias.yogi(1e-1)),
       ('dpsgd', lambda: alias.dpsgd(2e-3, 10., 0.001, 0, 0.2))
   )
   def test_rosenbrock(self, opt_name, opt):

--- a/optax/_src/transform.py
+++ b/optax/_src/transform.py
@@ -483,9 +483,9 @@ def scale_by_yogi(
   def update_fn(updates, state, params=None):
     del params
     mu = _update_moment(updates, state.mu, b1, 1)
-    signed_sq = jax.tree_multimap(
-        lambda g, v: jnp.sign(v - g**2)*g**2, updates, state.nu)
-    nu = _update_moment(signed_sq, state.nu, b2, 2)
+    nu = jax.tree_multimap(
+        lambda g, v: v - (1 - b2) * jnp.sign(v - g**2) * g**2,
+        updates, state.nu)
     count_inc = numerics.safe_int32_increment(state.count)
     mu_hat = _bias_correction(mu, b1, count_inc)
     nu_hat = _bias_correction(nu, b2, count_inc)


### PR DESCRIPTION
When I was implementing #279, I noticed that the Yogi optimizer was incorrectly implemented. We should not take the square of `signed_sq` in `_update_moment`, and the coefficient to update `v` is also different from that in `_update_moment`.

After the fix, I need to change the learning rate to pass the test.