### PR TITLE
Enhance `ctc_loss` to return forward probs.

### DIFF
--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -70,6 +70,7 @@ from optax._src.lookahead import LookaheadState
 from optax._src.loss import cosine_distance
 from optax._src.loss import cosine_similarity
 from optax._src.loss import ctc_loss
+from optax._src.loss import ctc_loss_with_forward_probs
 from optax._src.loss import huber_loss
 from optax._src.loss import l2_loss
 from optax._src.loss import log_cosh
@@ -183,6 +184,7 @@ __all__ = (
     "ClipState",
     "constant_schedule",
     "ctc_loss",
+    "ctc_loss_with_forward_probs",
     "control_delta_method",
     "control_variates_jacobians",
     "cosine_decay_schedule",


### PR DESCRIPTION
Continuing from #293, we found some use cases where interim alpha probabilities are useful.
This PR renames `ctc_loss` to `ctc_loss_with_foward_probs` and make `ctc_loss` to be an alias to `ctc_loss_with_forward_probs` with omitting auxiliary outputs.
