### PR TITLE
Rename argument names for CTC loss functions.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -434,6 +434,7 @@ Common Losses
     cosine_distance
     cosine_similarity
     ctc_loss
+    ctc_loss_with_forward_probs
     huber_loss
     l2_loss
     log_cosh
@@ -448,6 +449,7 @@ Losses
 .. autofunction:: cosine_distance
 .. autofunction:: cosine_similarity
 .. autofunction:: ctc_loss
+.. autofunction:: ctc_loss_with_forward_probs
 .. autofunction:: huber_loss
 .. autofunction:: l2_loss
 .. autofunction:: log_cosh


### PR DESCRIPTION
This PR is fixing some issues mentioned in the follow-up discussions on #321 

The docstring is now confirmed to be correctly rendered to HTMLs.
Since the arguments are renamed, the old code with invocating ctc_loss with keyword arguments will break after merging this change.
