### PR TITLE
[Docs] softmax_cross_entropy_with_integer_label

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -461,6 +461,7 @@ Losses
 .. autofunction:: sigmoid_binary_cross_entropy
 .. autofunction:: smooth_labels
 .. autofunction:: softmax_cross_entropy
+.. autofunction:: softmax_cross_entropy_with_integer_labels
 
 
 


### PR DESCRIPTION
Document for the new loss function is missing from Readthedocs.