### PR TITLE
Add support for PolyLoss (ICLR 2022)

### DIFF
--- a/optax/_src/loss.py
+++ b/optax/_src/loss.py
@@ -129,9 +129,8 @@ def smooth_labels(
     [Müller et al, 2019](https://arxiv.org/pdf/1906.02629.pdf)
 
   Args:
-    labels: one hot labels to be smoothed.
-    alpha: the smoothing factor, the greedy category with be assigned
-      probability `(1-alpha) + alpha / num_categories`
+    labels: One hot labels to be smoothed.
+    alpha: The smoothing factor.
 
   Returns:
     a smoothed version of the one hot input labels.
@@ -601,7 +600,7 @@ def poly_loss_cross_entropy(logits: chex.Array,
     \frac{1}{N + 1} \cdot (1 - P_t)^{N + 1} + \ldots = \\
     - \log(P_t) + \sum_{j = 1}^N \epsilon_j \cdot (1 - P_t)^j
 
-  This function provides a simplified version of the :math:`L_{Poly-N}`
+  This function provides a simplified version of :math:`L_{Poly-N}`
   with only the coefficient of the first polynomial term being changed.
 
     References:
@@ -609,15 +608,15 @@ def poly_loss_cross_entropy(logits: chex.Array,
 
     Args:
       logits: Unnormalized log probabilities, with shape `[..., num_classes]`.
-      labels: Valid probability distributions (non-negative, sum to 1), e.g a
+      labels: Valid probability distributions (non-negative, sum to 1), e.g. a
         one hot encoding specifying the correct class for each input;
         must have a shape broadcastable to `[..., num_classes]`.
       epsilon: The coefficient of the first polynomial term.
         According to the paper, the following values are recommended:
         - For the ImageNet 2d image classification, epsilon = 2.0.
         - For the 2d Instance Segmentation and object detection, epsilon = -1.0.
-        - It is also recommended to adjust this value
-          based on the task, e.g. by using grid search.
+        - It is also recommended to adjust this value based on the task, e.g. by
+          using grid search.
 
     Returns:
       Poly loss between each prediction and the corresponding target
@@ -629,6 +628,5 @@ def poly_loss_cross_entropy(logits: chex.Array,
     labels * (1 - jax.nn.softmax(logits)), axis=-1)
 
   cross_entropy = softmax_cross_entropy(logits=logits, labels=labels)
-  poly_loss = cross_entropy + epsilon * one_minus_pt
 
-  return poly_loss
+  return cross_entropy + epsilon * one_minus_pt

--- a/optax/_src/loss.py
+++ b/optax/_src/loss.py
@@ -523,9 +523,8 @@ def hinge_loss(predictor_outputs: chex.Array,
 
 def poly_loss_cross_entropy(logits: chex.Array,
                             labels: chex.Array,
-                            epsilon: float = 2.0,
-                            alpha: float = 0.0) -> chex.Array:
-  r"""Computes PolyLoss with alpha-label smoothing between logits and labels.
+                            epsilon: float = 2.0) -> chex.Array:
+  r"""Computes PolyLoss between logits and labels.
 
   The PolyLoss is a loss function that decomposes commonly
   used classification loss functions into a series of weighted
@@ -549,28 +548,24 @@ def poly_loss_cross_entropy(logits: chex.Array,
       logits: Unnormalized log probabilities, with shape `[..., num_classes]`.
       labels: Valid probability distributions (non-negative, sum to 1), e.g a
         one hot encoding specifying the correct class for each input;
-        must have a shape broadcastable to `[..., num_classes]``
-      epsilon: The coefficient of the first polynomial term (default = 2.0).
+        must have a shape broadcastable to `[..., num_classes]`.
+      epsilon: The coefficient of the first polynomial term.
         According to the paper, the following values are recommended:
-        - For the ImageNet 2d image classification, epsilon = 2.0
-        - For the 2d Instance Segmentation and object detection, epsilon = -1.0
+        - For the ImageNet 2d image classification, epsilon = 2.0.
+        - For the 2d Instance Segmentation and object detection, epsilon = -1.0.
         - It is also recommended to adjust this value
-          based on the task and dataset at hand. For example, one can use
-          simple grid search to achieve it.
-      alpha: The smoothing factor, the greedy category with be assigned
-        probability `(1-alpha) + alpha / num_categories` (default = 0.0)
+          based on the task, e.g. by using grid search.
 
     Returns:
-      poly loss between each prediction and the corresponding target
+      Poly loss between each prediction and the corresponding target
       distributions, with shape `[...]`.
     """
-  chex.assert_type([logits], float)
+  chex.assert_type([logits, labels], float)
 
-  smoothed_labels = smooth_labels(labels=labels, alpha=alpha)
   one_minus_pt = jnp.sum(
-    smoothed_labels * (1 - jax.nn.softmax(logits)), axis=-1)
+    labels * (1 - jax.nn.softmax(logits)), axis=-1)
 
-  cross_entropy = softmax_cross_entropy(logits=logits, labels=smoothed_labels)
+  cross_entropy = softmax_cross_entropy(logits=logits, labels=labels)
   poly_loss = cross_entropy + epsilon * one_minus_pt
 
   return poly_loss

--- a/optax/_src/loss_test.py
+++ b/optax/_src/loss_test.py
@@ -577,7 +577,6 @@ class PolyLossTest(parameterized.TestCase):
       dict(eps=0, expected=2.8990),
       dict(eps=-0.5, expected=2.4908),
       dict(eps=1.15, expected=3.8378),
-      dict(eps=2, expected=4.5317),
       dict(eps=1.214, expected=3.8900),
       dict(eps=5.45, expected=7.3480),
   )
@@ -596,7 +595,6 @@ class PolyLossTest(parameterized.TestCase):
       dict(eps=0, expected=np.array([0.1698, 0.8247])),
       dict(eps=-0.5, expected=np.array([0.0917, 0.7168])),
       dict(eps=1.15, expected=np.array([0.3495, 1.0731])),
-      dict(eps=2, expected=np.array([0.4823, 1.2567])),
       dict(eps=1.214, expected=np.array([0.3595, 1.0870])),
       dict(eps=5.45, expected=np.array([1.0211, 2.0018])),
   )

--- a/optax/_src/loss_test.py
+++ b/optax/_src/loss_test.py
@@ -511,43 +511,40 @@ class PolyLossTest(parameterized.TestCase):
 
   @chex.all_variants
   @parameterized.parameters(
-      dict(eps=2, alpha=0, expected=4.531657285679147),
-      dict(eps=1, alpha=0, expected=3.7153301084365054),
-      dict(eps=-1, alpha=0, expected=2.082675753951222),
-      dict(eps=0, alpha=0, expected=2.8990029311938637),
-      dict(eps=-0.5, alpha=0, expected=2.490839342572543),
-      dict(eps=1.15, alpha=0, expected=3.8377791850229013),
-      dict(eps=2, alpha=0.01, expected=4.527930742134294),
-      dict(eps=2, alpha=0.1, expected=4.494391850230619),
-      dict(eps=1.214, alpha=0.2415, expected=3.8031273062152553),
-      dict(eps=5.45, alpha=0.7515, expected=7.025605235513005),
+      dict(eps=2, expected=4.5317),
+      dict(eps=1, expected=3.7153),
+      dict(eps=-1, expected=2.0827),
+      dict(eps=0, expected=2.8990),
+      dict(eps=-0.5, expected=2.4908),
+      dict(eps=1.15, expected=3.8378),
+      dict(eps=2, expected=4.5317),
+      dict(eps=1.214, expected=3.8900),
+      dict(eps=5.45, expected=7.3480),
   )
-  def test_scalar(self, eps, alpha, expected):
+  def test_scalar(self, eps, expected):
     np.testing.assert_allclose(
         self.variant(loss.poly_loss_cross_entropy)(self.logits,
                                                    self.labels,
-                                                   eps, alpha),
+                                                   eps),
         expected,
         atol=1e-4)
 
   @chex.all_variants
   @parameterized.parameters(
-      dict(eps=2, alpha=0, expected=np.array([0.48225655, 1.25670369])),
-      dict(eps=1, alpha=0, expected=np.array([0.32605129, 1.04072429])),
-      dict(eps=-1, alpha=0, expected=np.array([0.01364075, 0.60876549])),
-      dict(eps=0, alpha=0, expected=np.array([0.16984602, 0.82474489])),
-      dict(eps=-0.5, alpha=0, expected=np.array([0.09174339, 0.71675519])),
-      dict(eps=1.15, alpha=0, expected=np.array([0.34948207, 1.0731212])),
-      dict(eps=2, alpha=0.01, expected=np.array([0.50913245, 1.28771743])),
-      dict(eps=2, alpha=0.1, expected=np.array([0.7510155, 1.56684114])),
-      dict(eps=1.214, alpha=0.2415, expected=np.array([0.9116368, 1.75037682])),
-      dict(eps=5.45, alpha=0.7515, expected=np.array([4.36434872, 5.50100119])),
+      dict(eps=2, expected=np.array([0.4823, 1.2567])),
+      dict(eps=1, expected=np.array([0.3261, 1.0407])),
+      dict(eps=0, expected=np.array([0.1698, 0.8247])),
+      dict(eps=-0.5, expected=np.array([0.0917, 0.7168])),
+      dict(eps=1.15, expected=np.array([0.3495, 1.0731])),
+      dict(eps=2, expected=np.array([0.4823, 1.2567])),
+      dict(eps=1.214, expected=np.array([0.3595, 1.0870])),
+      dict(eps=5.45, expected=np.array([1.0211, 2.0018])),
   )
-  def test_batched(self, eps, alpha, expected):
+  def test_batched(self, eps, expected):
     np.testing.assert_allclose(
         self.variant(loss.poly_loss_cross_entropy)(self.batched_logits,
                                                    self.batched_labels,
-                                                   eps, alpha),
+                                                   eps),
         expected,
         atol=1e-4)
 
@@ -572,7 +569,7 @@ class PolyLossTest(parameterized.TestCase):
   )
   def test_equals_to_cross_entropy_when_eps0(self, logits, labels):
     np.testing.assert_allclose(
-        self.variant(loss.poly_loss_cross_entropy)(logits, labels, 0., 0.),
+        self.variant(loss.poly_loss_cross_entropy)(logits, labels, epsilon=0.),
         self.variant(loss.softmax_cross_entropy)(logits, labels),
         atol=1e-4)
 


### PR DESCRIPTION
Closes #466 

I focused on implementing the Poly-1 cross entropy loss with alpha-label smoothing since, as it is shown in the paper, the first term plays the most important role. Also, I crafted a small test showing that the behavior is indeed similar to the one of the `softmax_cross_entropy` when `\epsilon = 0`

I didn't add it to `optax/__init__.py` and `docs/api.rst` files yet (would it be ok to do that in a separate PR?)

Please, let me know what you think!
