### PR TITLE
feat(ci/tests): bump `setup-python` version and enable cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,11 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/setup-python@v4"
         with:
             python-version: "${{ matrix.python-version }}"
+            cache: "pip"
+            cache-dependency-path: '**/requirements*.txt'
       - name: Run CI tests
         run: bash test.sh
         shell: bash


### PR DESCRIPTION
Changes made by this PR can be summarized as follows:

- Bump the version to `actions/setup-python` to `v4`.
- Set the `cache` and `cache-dependency-path` argument of `actions/setup-python` to enable `pip` caching.