### PR TITLE
Explicitly export "softmax_cross_entropy_with_integer_labels"

### DIFF
--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -326,6 +326,7 @@ __all__ = (
     "sm3",
     "smooth_labels",
     "softmax_cross_entropy",
+    "softmax_cross_entropy_with_integer_labels",
     "stateless",
     "stateless_with_tree_map",
     "trace",


### PR DESCRIPTION
Explicitly export `softmax_cross_entropy_with_integer_labels`